### PR TITLE
added library(caTools)

### DIFF
--- a/run_spp.R
+++ b/run_spp.R
@@ -535,6 +535,10 @@ check.replace.flag <- function(params){
 # MAIN FUNCTION
 # #############################################################################
 
+# Load SPP library
+library(spp)
+library(caTools)
+
 # Check number of arguments
 minargs = 1;
 maxargs = 17;
@@ -645,9 +649,6 @@ if (! is.na(iparams$control.file)) {
 		file.remove(curr.control.file)
 	}
 }
-
-# Load SPP library
-library(spp)
 
 # Read ChIP tagAlign/BAM files
 cat("Reading ChIP tagAlign/BAM file",iparams$chip.file,"\n",file=stdout())


### PR DESCRIPTION
`caTools::runmean` is used within the `run_spp` script.
But `caTools` was neither imported explicitly nor was `runmean` called in `<namespace>::<function>` format. 
Hence, after an hour of processing, `run_spp` died on my computer with error `could not find function "runmean" `.

I put the global `library` calls at the start of your `MAIN FUNCTION` to ensure that the script dies immediately if the user does not have these functions installed.